### PR TITLE
Adds post details view

### DIFF
--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -19,11 +19,6 @@ export const NavBar = ({ loggedInUser, setLoggedInUser }) => {
           </Link>
         )}
       </li>
-      <li className="navbar-item">
-        <Link to="/bruh" className="navbar-link" id={url === "/bruh" ? "selected" : ""}>
-          [example link]
-        </Link>
-      </li>
 
       {/*//* add more navbar items here */}
 

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -4,6 +4,7 @@ import { Login } from "../auth/Login"
 import { Register } from "../auth/Register"
 import { AuthorizedRoute } from "../auth/AuthorizedRoute"
 import { NavBar } from "../nav/NavBar"
+import { PostDetails } from "./posts/PostDetails"
 
 export const ApplicationViews = () => {
   const [loggedInUser, setLoggedInUser] = useState(null)
@@ -32,8 +33,10 @@ export const ApplicationViews = () => {
           </AuthorizedRoute>
         }>
         <Route index element={<>Rare - Home Page</>} /> {/* home page will go here */}
-        <Route path="/bruh" element={<>[example path]</>} />
-        {/*//* add more application routes here */}
+        <Route path="/post-details">
+          <Route index element={<Navigate to={"/"} state={{ from: location }} replace />} />
+          <Route path=":postId" element={<PostDetails />} />
+        </Route>
       </Route>
 
       <Route

--- a/src/components/views/posts/PostDetails.css
+++ b/src/components/views/posts/PostDetails.css
@@ -1,0 +1,32 @@
+.post-details__container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  background-color: #f9f9f9;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  font-family: "Lato", sans-serif;
+}
+
+.post-details__title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+
+.post-details__date,
+.post-details__username {
+  font-size: 18px;
+  color: #666;
+  margin-bottom: 10px;
+}
+.post-details__username-name {
+  color: black;
+}
+
+.post-details__content {
+  font-size: 16px;
+  line-height: 1.5;
+  margin-top: 20px;
+}

--- a/src/components/views/posts/PostDetails.css
+++ b/src/components/views/posts/PostDetails.css
@@ -14,7 +14,6 @@
   margin-bottom: 10px;
   font-weight: bold;
 }
-
 .post-details__date,
 .post-details__username {
   font-size: 18px;
@@ -24,9 +23,23 @@
 .post-details__username-name {
   color: black;
 }
-
-.post-details__content {
+.post-details__body {
   font-size: 16px;
   line-height: 1.5;
   margin-top: 20px;
+}
+.post-details__img {
+  height: 40px;
+  width: 60%;
+  object-fit: cover;
+}
+
+.post-details__content-a,
+.post-details__content-b {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.post-details__content-a {
+  margin-bottom: 10px;
 }

--- a/src/components/views/posts/PostDetails.js
+++ b/src/components/views/posts/PostDetails.js
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { getPostById } from "../../../managers/postManager"
-import { isEmptyObject } from "../../../helper"
+import { formatDate, isEmptyObject } from "../../../helper"
+import "./PostDetails.css"
 
 export const PostDetails = () => {
   const [post, setPost] = useState(null)
@@ -22,11 +23,13 @@ export const PostDetails = () => {
     <div className="post-details__container">
       {!isEmptyObject(post) && post && (
         <>
-          <div className="post-details__title">Title: {post.title}</div>
-          <div className="post-details__img">Image: {post.image_url}</div>
-          <div className="post-details__content">Content:</div>
-          <div className="post-details__date">Date (MM/DD/YYYY):</div>
-          <div className="post-details__username">Username:</div>
+          <h1 className="post-details__title">{post.title}</h1>
+          {/* <div className="post-details__img">Image: {post.image_url}</div> */}
+          <h3 className="post-details__date">Published on {formatDate(post.publication_date)}</h3>
+          <h3 className="post-details__username">
+            By <i className="post-details__username-name">{post.user.username}</i>
+          </h3>
+          <p className="post-details__content">{post.content}</p>
         </>
       )}
     </div>

--- a/src/components/views/posts/PostDetails.js
+++ b/src/components/views/posts/PostDetails.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { getPostById } from "../../../managers/postManager"
+import { isEmptyObject } from "../../../helper"
+
+export const PostDetails = () => {
+  const [post, setPost] = useState(null)
+  const { postId } = useParams()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    getPostById(parseInt(postId)).then(setPost)
+  }, [postId])
+
+  useEffect(() => {
+    if (isEmptyObject(post)) {
+      navigate("/")
+    }
+  }, [navigate, post])
+
+  return (
+    <div className="post-details__container">
+      {!isEmptyObject(post) && post && (
+        <>
+          <div className="post-details__title">Title: {post.title}</div>
+          <div className="post-details__img">Image: {post.image_url}</div>
+          <div className="post-details__content">Content:</div>
+          <div className="post-details__date">Date (MM/DD/YYYY):</div>
+          <div className="post-details__username">Username:</div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/views/posts/PostDetails.js
+++ b/src/components/views/posts/PostDetails.js
@@ -23,13 +23,17 @@ export const PostDetails = () => {
     <div className="post-details__container">
       {!isEmptyObject(post) && post && (
         <>
-          <h1 className="post-details__title">{post.title}</h1>
-          {/* <div className="post-details__img">Image: {post.image_url}</div> */}
-          <h3 className="post-details__date">Published on {formatDate(post.publication_date)}</h3>
-          <h3 className="post-details__username">
-            By <i className="post-details__username-name">{post.user.username}</i>
-          </h3>
-          <p className="post-details__content">{post.content}</p>
+          <div className="post-details__content-a">
+            <h1 className="post-details__title">{post.title}</h1>
+            {post.image_url && <img className="post-details__img" alt="header" src={post.image_url} />}
+          </div>
+          <div className="post-details__content-b">
+            <h3 className="post-details__date">Published on {formatDate(post.publication_date)}</h3>
+            <h3 className="post-details__username">
+              By <i className="post-details__username-name">{post.user.username}</i>
+            </h3>
+          </div>
+          <p className="post-details__body">{post.content}</p>
         </>
       )}
     </div>

--- a/src/helper.js
+++ b/src/helper.js
@@ -24,3 +24,9 @@ export const isEmptyObject = (obj) => {
   }
   return false
 }
+
+// converts YYYY-MM-DD to MM/DD/YYYY
+export const formatDate = (date) => {
+  const newDate = new Date(date.replace(/-/g, "/"))
+  return `${newDate.getMonth() + 1}/${newDate.getDate()}/${newDate.getFullYear()}`
+}

--- a/src/managers/postManager.js
+++ b/src/managers/postManager.js
@@ -1,0 +1,9 @@
+import { apiUrl } from "../helper"
+
+export const getPosts = async () => {
+  return await fetch(`${apiUrl}/posts`).then((res) => res.json())
+}
+
+export const getPostById = async (id) => {
+  return await fetch(`${apiUrl}/posts/${id}`).then((res) => res.json())
+}


### PR DESCRIPTION
This pull request adds the functionality to view the details of a post when a user is logged in.

Testing info:
1. Run the `server.py` file to start the server.
2. Run `npm start` in the client directory to start the project.
3. This test will require some test data.
    - A user, so you can log in.
    - At least one post, so you can view its details.
4. Log in.
5. Once logged in, navigate to `/post-details/n` where `n` is equal to the `id` of your post in the database
    - _This is currently only accessible via manually typing the url, because the**Post** view functionality has not yet been implemented._
6. When viewing the details, you should see the `title`, `publication date`, `author`, `body`, and `header image` (if there is one) of the current post.
7. If attempting to view a post that does not exist, the user should be navigated back to the home page ("`/`").


Ticket #43