### PR TITLE
Deleting categories functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="https://kit.fontawesome.com/56c9a9b5ec.js" crossorigin="anonymous"></script>
     <title>Rare Publishing</title>
   </head>
   <body>

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -8,8 +8,8 @@ import { CreateTagForm } from "./tags/CreateTagForm.js"
 import { TagList } from "./tags/TagList.js"
 import { PostDetails } from "./posts/PostDetails"
 import { UserPostList } from "./posts/UserPosts.js"
-import CategoryList from "./categories/CategoryList.js"
-import CategoryForm from "./categories/CategoryForm.js"
+import { CategoryList } from "./categories/CategoryList.js"
+import { CategoryForm } from "./categories/CategoryForm.js"
 import { PostsList } from "./posts/PostsList.js"
 
 export const ApplicationViews = () => {

--- a/src/components/views/categories/CategoryForm.js
+++ b/src/components/views/categories/CategoryForm.js
@@ -2,26 +2,22 @@ import React, { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { createCategory } from "../../../managers/categoryManager"
 
-const CategoryForm = () => {
+export const CategoryForm = () => {
   const [categoryLabel, setCategoryLabel] = useState("")
   const navigate = useNavigate()
 
   const handleSaveCategory = async () => {
-    try {
-      const trimmedLabel = categoryLabel.trim()
+    const trimmedLabel = categoryLabel.trim()
 
-      if (trimmedLabel) {
-        const newCategory = {
-          label: trimmedLabel,
-        }
-
-        await createCategory(newCategory)
-        navigate("/category-list")
-      } else {
-        console.error("Category label is empty or contains only whitespaces")
+    if (trimmedLabel) {
+      const newCategory = {
+        label: trimmedLabel,
       }
-    } catch (error) {
-      console.error("Error saving category:", error)
+
+      await createCategory(newCategory)
+      navigate("/category-list")
+    } else {
+      window.alert("Category label is empty or contains only whitespaces")
     }
   }
 
@@ -34,5 +30,3 @@ const CategoryForm = () => {
     </div>
   )
 }
-
-export default CategoryForm

--- a/src/components/views/categories/CategoryList.css
+++ b/src/components/views/categories/CategoryList.css
@@ -19,3 +19,8 @@
 .category-list__left > * {
   margin-bottom: 10px;
 }
+
+.category__delete-btn:hover {
+  color: red;
+  cursor: pointer;
+}

--- a/src/components/views/categories/CategoryList.css
+++ b/src/components/views/categories/CategoryList.css
@@ -1,20 +1,21 @@
-.category-list-container {
+.category-list__container {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 20px;
+  font-family: "Lato", sans-serif;
 }
 
-.category-list-content {
+.category-list__content {
   display: flex;
   width: 100%;
   justify-content: space-between;
 }
 
-.category-list-left {
-  flex: 1;
+.category-list__content > * {
+  max-width: 600px;
 }
 
-.category-list-right {
-  max-width: 200px; /* Adjust as needed */
+.category-list__left > * {
+  margin-bottom: 10px;
 }

--- a/src/components/views/categories/CategoryList.js
+++ b/src/components/views/categories/CategoryList.js
@@ -7,12 +7,20 @@ import { Button, ListGroup, ListGroupItem } from "reactstrap"
 export const CategoryList = () => {
   const [allCategories, setAllCategories] = useState([])
 
+  const handleDelete = (e, category) => {
+    e.preventDefault()
+    if (window.confirm(`Are you sure you want to delete the "${category}" category?`)) {
+      //!
+    }
+  }
+
   useEffect(() => {
     getAllCategories().then((categoriesArr) => {
       const sortedCategories = categoriesArr.sort((a, b) => a.label.localeCompare(b.label))
       setAllCategories(sortedCategories)
     })
   }, [])
+
   return (
     <div className="category-list__container">
       <h1>Category List Page</h1>
@@ -23,7 +31,12 @@ export const CategoryList = () => {
           <ListGroup className="category-list">
             {allCategories.map((category) => (
               <ListGroupItem key={category.id} className="category">
-                <i className="fa-solid fa-trash category__delete-btn" />
+                <i
+                  className="fa-solid fa-trash category__delete-btn"
+                  onClick={(e) => {
+                    handleDelete(e, category.label)
+                  }}
+                />
                 &emsp;{category.label}
               </ListGroupItem>
             ))}

--- a/src/components/views/categories/CategoryList.js
+++ b/src/components/views/categories/CategoryList.js
@@ -23,7 +23,8 @@ export const CategoryList = () => {
           <ListGroup className="category-list">
             {allCategories.map((category) => (
               <ListGroupItem key={category.id} className="category">
-                {category.label}
+                <i className="fa-solid fa-trash category__delete-btn" />
+                &emsp;{category.label}
               </ListGroupItem>
             ))}
           </ListGroup>

--- a/src/components/views/categories/CategoryList.js
+++ b/src/components/views/categories/CategoryList.js
@@ -1,24 +1,28 @@
 import React, { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
-import { getAllCategories } from "../../../managers/categoryManager"
+import { deleteCategory, getAllCategories } from "../../../managers/categoryManager"
 import "./CategoryList.css"
 import { Button, ListGroup, ListGroupItem } from "reactstrap"
 
 export const CategoryList = () => {
   const [allCategories, setAllCategories] = useState([])
 
-  const handleDelete = (e, category) => {
-    e.preventDefault()
-    if (window.confirm(`Are you sure you want to delete the "${category}" category?`)) {
-      //!
-    }
-  }
-
-  useEffect(() => {
+  const getAndSetCategories = () => {
     getAllCategories().then((categoriesArr) => {
       const sortedCategories = categoriesArr.sort((a, b) => a.label.localeCompare(b.label))
       setAllCategories(sortedCategories)
     })
+  }
+
+  const handleDelete = (e, category) => {
+    e.preventDefault()
+    if (window.confirm(`Are you sure you want to delete the "${category.label}" category?`)) {
+      deleteCategory(category).then(getAndSetCategories)
+    }
+  }
+
+  useEffect(() => {
+    getAndSetCategories()
   }, [])
 
   return (
@@ -34,7 +38,7 @@ export const CategoryList = () => {
                 <i
                   className="fa-solid fa-trash category__delete-btn"
                   onClick={(e) => {
-                    handleDelete(e, category.label)
+                    handleDelete(e, category)
                   }}
                 />
                 &emsp;{category.label}

--- a/src/components/views/categories/CategoryList.js
+++ b/src/components/views/categories/CategoryList.js
@@ -14,27 +14,25 @@ export const CategoryList = () => {
     })
   }, [])
   return (
-    <div className="category-list-container">
+    <div className="category-list__container">
       <h1>Category List Page</h1>
 
-      <div className="category-list-content">
-        <div className="category-list-left">
+      <div className="category-list__content">
+        <div className="category-list__left">
           <h2>Existing Categories:</h2>
-          <ListGroup>
+          <ListGroup className="category-list">
             {allCategories.map((category) => (
-              <ListGroupItem key={category.id}>{category.label}</ListGroupItem>
+              <ListGroupItem key={category.id} className="category">
+                {category.label}
+              </ListGroupItem>
             ))}
           </ListGroup>
         </div>
 
-        <div className="category-list-right">
-          <Link to="/createCategory">
-            <Button color="primary">Create Category</Button>
-          </Link>
-        </div>
+        <Link to="/createCategory">
+          <Button color="primary">Create Category</Button>
+        </Link>
       </div>
     </div>
   )
 }
-
-export default CategoryList

--- a/src/components/views/posts/PostsList.js
+++ b/src/components/views/posts/PostsList.js
@@ -28,8 +28,8 @@ export const PostsList = () => {
         <h1 className="posts-list__header">All Posts</h1>
         {filteredPosts.length > 0 ? (
           filteredPosts.map((post) => (
-            <Link to={`/post-details/${post.id}`} className="post__link">
-              <ul key={post.id} className="post__container">
+            <Link key={post.id} to={`/post-details/${post.id}`} className="post__link">
+              <ul className="post__container">
                 <div className="post__content-a">
                   <li className="post__title">{post.title}</li>
                   <li className="post__category">{post.category.label}</li>

--- a/src/components/views/posts/UserPosts.js
+++ b/src/components/views/posts/UserPosts.js
@@ -28,8 +28,8 @@ export const UserPostList = ({ loggedInUser }) => {
         <h1 className="posts-list__header">My Posts</h1>
         {filteredPosts.length > 0 ? (
           filteredPosts.map((post) => (
-            <Link to={`/post-details/${post.id}`} className="post__link">
-              <ul key={post.id} className="post__container">
+            <Link key={post.id} to={`/post-details/${post.id}`} className="post__link">
+              <ul className="post__container">
                 <div className="post__content-a">
                   <li className="post__title">{post.title}</li>
                   <li className="post__category">{post.category.label}</li>

--- a/src/managers/categoryManager.js
+++ b/src/managers/categoryManager.js
@@ -1,13 +1,13 @@
-export const createCategory = (category) => {
-  return fetch(`http://localhost:8000/categories`, {
-    method: "POST",
-    headers: {
-      "Content-type": "application/json",
-    },
-    body: JSON.stringify(category),
-  })
+import { apiUrl, fetchOptions } from "../helper"
+
+export const createCategory = async (category) => {
+  return await fetch(`${apiUrl}/categories`, fetchOptions("POST", category)).then((res) => res.json())
 }
 
-export const getAllCategories = () => {
-  return fetch("http://localhost:8000/categories").then((res) => res.json())
+export const getAllCategories = async () => {
+  return await fetch(`${apiUrl}/categories`).then((res) => res.json())
+}
+
+export const deleteCategory = async (category) => {
+  return await fetch(`${apiUrl}/categories/${category.id}`, fetchOptions("DELETE")).then((res) => res.json())
 }


### PR DESCRIPTION
This pull request adds the functionality to delete categories from the database.

Testing info:
1. This test will require you to have some `categories` in your database. If you do not already have some, you can create a few by using the existing category creation feature in the client-side. Alternatively, you can execute the following code to manually create a few `categories` in your database:
```sql
INSERT INTO Categories ('label')
VALUES ('Coding');

INSERT INTO Categories ('label')
VALUES ('Art');

INSERT INTO Categories ('label')
VALUES ('Puzzles');
```
2. Run the `server.py` file in the api directory to start the server.
3. Run `npm start` in the client directory to start the project.
4. Log in, if you aren't already.
5. Once logged in, click on **Category Manager** to view the list of all categories in the database.
6. Each category should have a trash can icon on the left.
7. Clicking on any of these icons should cause a window prompt to appear, which asks "Are you sure you want to delete the "`label`" category?", where `label` is equal to the name of the clicked category.
8. Clicking "Cancel" should take you back to the category page, with no effect.
9. Clicking "OK" should take you back to the category page, with the corresponding category no longer appearing in the list.


Ticket #32