### PR TITLE
Tag Deletion Functionality

### DIFF
--- a/src/components/views/tags/TagList.js
+++ b/src/components/views/tags/TagList.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { getAllTags } from "../../../managers/tagManager.js"
+import { deleteTag, getAllTags } from "../../../managers/tagManager.js"
 import { sortAlphabetically } from "../../../helper.js"
 import "./TagList.css"
 import { Button, ListGroup, ListGroupItem } from "reactstrap"
@@ -9,11 +9,22 @@ export const TagList = () => {
   const [allTags, setAllTags] = useState([])
   const navigate = useNavigate()
 
-  useEffect(() => {
+  const getAndSetTags = () => {
     getAllTags().then((tagsArray) => {
-      const alphabetizedTags = sortAlphabetically(tagsArray, "label")
-      setAllTags(alphabetizedTags)
+      const sortedTags = sortAlphabetically(tagsArray, "label")
+      setAllTags(sortedTags)
     })
+  }
+
+  const handleDelete = (e, tag) => {
+    e.preventDefault()
+    if (window.confirm(`Are you sure you want to delete the "${tag.label}" tag?`)) {
+      deleteTag(tag).then(getAndSetTags)
+    }
+  }
+
+  useEffect(() => {
+    getAndSetTags()
   }, [])
 
   return (
@@ -24,7 +35,13 @@ export const TagList = () => {
           <ListGroup className="tag-list">
             {allTags.map((tag) => (
               <ListGroupItem key={tag.id} className="tag">
-                {tag.label}
+                <i
+                  className="fa-solid fa-trash tag__delete-btn"
+                  onClick={(e) => {
+                    handleDelete(e, tag)
+                  }}
+                />
+                &emsp;{tag.label}
               </ListGroupItem>
             ))}
           </ListGroup>

--- a/src/managers/tagManager.js
+++ b/src/managers/tagManager.js
@@ -7,3 +7,7 @@ export const getAllTags = async () => {
 export const createTag = async (tag) => {
   return await fetch(`${apiUrl}/tags`, fetchOptions("POST", tag)).then((res) => res.json())
 }
+
+export const deleteTag = async (tag) => {
+  return await fetch(`${apiUrl}/tags/${tag.id}`, fetchOptions("DELETE")).then((res) => res.json())
+}


### PR DESCRIPTION
This pull request adds the functionality to delete tags from the database.

Testing info:
1. This test will require you to have some `tags` in your database. If you do not already have some, you can create a few by using the existing tag creation feature in the client-side. Alternatively, you can execute the following code to manually create a few `tags` in your database:
```sql
INSERT INTO Tags ('label')
VALUES ('Python');

INSERT INTO Tags ('label')
VALUES ('SQL');

INSERT INTO Tags ('label')
VALUES ('Scratch');
```
2. Run the `server.py` file in the api directory to start the server.
3. Run `npm start` in the client directory to start the project.
4. Log in, if you aren't already.
5. Once logged in, click on **Tag Manager** to view the list of all tags in the database.
6. Each tag should have a trash can icon on the left.
7. Clicking on any of these icons should cause a window prompt to appear, which asks "Are you sure you want to delete the "`label`" tag?", where `label` is equal to the name of the clicked tag.
8. Clicking "Cancel" should take you back to the tag page, with no effect.
9. Clicking "OK" should take you back to the tag page, with the corresponding tag no longer appearing in the list.


Ticket #30