### PR TITLE
Edit Category Functionality

### DIFF
--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -42,6 +42,10 @@ export const ApplicationViews = () => {
         <Route path="/categories">
           <Route index element={<CategoryList />} />
           <Route path="create" element={<CategoryForm />} />
+          <Route path="edit">
+            <Route index element={<Navigate to={"/categories"} state={{ from: location }} replace />} />
+            <Route path=":categoryId" element={<CategoryForm isEditing={true} />} />
+          </Route>
         </Route>
         <Route path="/tags">
           <Route index element={<TagList />} />

--- a/src/components/views/categories/CategoryForm.css
+++ b/src/components/views/categories/CategoryForm.css
@@ -23,3 +23,9 @@
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+
+.category-form__btn-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/components/views/categories/CategoryForm.js
+++ b/src/components/views/categories/CategoryForm.js
@@ -14,15 +14,11 @@ export const CategoryForm = ({ isEditing }) => {
     const trimmedLabel = categoryLabel.trim()
 
     if (!!trimmedLabel) {
-      const newCategory = {
-        label: trimmedLabel,
-      }
-
       if (!isEditing) {
-        await createCategory(newCategory)
+        await createCategory({ label: trimmedLabel })
         navigate("/categories")
       } else {
-        await updateCategory(newCategory)
+        await updateCategory({ label: trimmedLabel, id: parseInt(categoryId) })
         navigate("/categories")
       }
     } else {

--- a/src/components/views/categories/CategoryForm.js
+++ b/src/components/views/categories/CategoryForm.js
@@ -1,43 +1,67 @@
-import React, { useState } from "react"
-import { useNavigate } from "react-router-dom"
-import { createCategory } from "../../../managers/categoryManager"
+import React, { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { createCategory, getCategory, updateCategory } from "../../../managers/categoryManager"
 import "./CategoryForm.css"
 import { Button } from "reactstrap"
 
-export const CategoryForm = () => {
+export const CategoryForm = ({ isEditing }) => {
   const [categoryLabel, setCategoryLabel] = useState("")
+  const [placeholder, setPlaceholder] = useState("New Category")
+  const { categoryId } = useParams()
   const navigate = useNavigate()
 
   const handleSaveCategory = async () => {
     const trimmedLabel = categoryLabel.trim()
 
-    if (trimmedLabel) {
+    if (!!trimmedLabel) {
       const newCategory = {
         label: trimmedLabel,
       }
 
-      await createCategory(newCategory)
-      navigate("/categories")
+      if (!isEditing) {
+        await createCategory(newCategory)
+        navigate("/categories")
+      } else {
+        await updateCategory(newCategory)
+        navigate("/categories")
+      }
     } else {
       window.alert("Category label is empty or contains only whitespaces")
     }
   }
 
+  useEffect(() => {
+    if (isEditing) {
+      getCategory(parseInt(categoryId)).then((category) => {
+        setCategoryLabel(category.label)
+        setPlaceholder(category.label)
+      })
+    }
+  }, [categoryId, isEditing])
+
   return (
     <div className="category-form__container">
       <div className="category-form__content">
         <div className="category-form__left">
-          <label htmlFor="categoryLabel">Create a Category:</label>
+          <label htmlFor="categoryLabel">{!isEditing ? "Create a" : "Edit"} Category:</label>
           <input
             type="text"
             id="categoryLabel"
             value={categoryLabel}
             onChange={(e) => setCategoryLabel(e.target.value)}
             className="category-form__input"
+            placeholder={placeholder}
           />
-          <Button onClick={handleSaveCategory} className="category-form__btn" color="primary">
-            Save
-          </Button>
+          <div className="category-form__btn-container">
+            <Button onClick={handleSaveCategory} className="category-form__save-btn" color="primary">
+              Save
+            </Button>
+            {isEditing && (
+              <Button onClick={() => navigate("/categories")} className="category-form__cancel-btn" color="danger">
+                Cancel
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/views/categories/CategoryList.css
+++ b/src/components/views/categories/CategoryList.css
@@ -21,6 +21,10 @@
 }
 
 .category__delete-btn:hover {
-  color: red;
+  color: rgb(255, 67, 67);
+  cursor: pointer;
+}
+.category__edit-btn:hover {
+  color: rgb(255, 178, 35);
   cursor: pointer;
 }

--- a/src/components/views/categories/CategoryList.js
+++ b/src/components/views/categories/CategoryList.js
@@ -36,6 +36,11 @@ export const CategoryList = () => {
             {allCategories.map((category) => (
               <ListGroupItem key={category.id} className="category">
                 <i
+                  className="fa-solid fa-gear category__edit-btn"
+                  onClick={() => navigate(`/categories/edit/${category.id}`)}
+                />
+                &ensp;
+                <i
                   className="fa-solid fa-trash category__delete-btn"
                   onClick={(e) => {
                     handleDelete(e, category)

--- a/src/managers/categoryManager.js
+++ b/src/managers/categoryManager.js
@@ -8,6 +8,14 @@ export const getAllCategories = async () => {
   return await fetch(`${apiUrl}/categories`).then((res) => res.json())
 }
 
+export const getCategory = async (categoryId) => {
+  return await fetch(`${apiUrl}/categories/${categoryId}`).then((res) => res.json())
+}
+
 export const deleteCategory = async (category) => {
   return await fetch(`${apiUrl}/categories/${category.id}`, fetchOptions("DELETE")).then((res) => res.json())
+}
+
+export const updateCategory = async (category) => {
+  return await fetch(`${apiUrl}/categories/${category.id}`, fetchOptions("PUT", category)).then((res) => res.json())
 }


### PR DESCRIPTION
This pull request adds the functionality to edit categories in the database.

Testing info:
1. This test will require you to have some `categories` in your database. If you do not already have some, you can create a few by using the existing category creation feature in the client-side. Alternatively, you can execute the following code to manually create a few `categories` in your database:
```sql
INSERT INTO Categories ('label')
VALUES ('Software');

INSERT INTO Categories ('label')
VALUES ('Bugfix');

INSERT INTO Categories ('label')
VALUES ('Programming');
```
2. Run the `server.py` file in the api directory to start the server.
3. Run `npm start` in the client directory to start the project.
4. Log in, if you aren't already.
5. Once logged in, click on **Category Manager** to view the list of all categories in the database.
6. Each category should have a gear icon on the left.
7. Clicking on any of these icons should take you to the **Edit Category** page.
8. The **Edit Category** page should have an input that is populated by the current category's label.
9. Clicking "Cancel" should take you back to the category page, with no effect.
10. Clicking "Save" after entering a new category label should take you back to the category page, with the corresponding category now having the new label.


Ticket #31